### PR TITLE
Update name in help command

### DIFF
--- a/lbry-format.js
+++ b/lbry-format.js
@@ -3,7 +3,7 @@ const { packDirectory, unpackDirectory } = require("lbry-format");
 const path = require("path");
 
 require("yargs")
-  .scriptName("lbry-pack")
+  .scriptName("lbry-format")
   .usage("$0 <cmd> [args]")
   .command(
     "pack [directory] [file] [-t]",


### PR DESCRIPTION
Changed the name from `lbry-pack` to `lbry-format` which is the current name of the executable
![Screenshot_20191227_064136](https://user-images.githubusercontent.com/37413895/71484982-f1b8ed80-2873-11ea-9e5d-854f11c1739d.png)
